### PR TITLE
Potential fix for code scanning alert no. 73: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/rcedros/juice-shop-ada-1497/security/code-scanning/73](https://github.com/rcedros/juice-shop-ada-1497/security/code-scanning/73)

The optimal fix is to refactor the MongoDB query to avoid dynamic code evaluation via `$where`. Instead, use a regular MongoDB field query with parameterization. Specifically, replace the `$where` predicate with an equality match using the `orderId` field. The query should look like `{ orderId: id }`. This removes any possibility of code injection and is more efficient. The edit should be made on line 18 in `routes/trackOrder.ts`, changing `db.ordersCollection.find({ $where: ... })` to `db.ordersCollection.find({ orderId: id })`. No additional imports or methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
